### PR TITLE
PR: Implementação do Executor de Lances e Refatoração de Roque (Chess960)

### DIFF
--- a/backend/src/main/java/com/chess/entity/base/Direction.java
+++ b/backend/src/main/java/com/chess/entity/base/Direction.java
@@ -1,5 +1,7 @@
 package com.chess.entity.base;
 
+import java.util.Objects;
+
 public class Direction {
     // Valores do vetor direção
     private final int x;
@@ -60,9 +62,8 @@ public class Direction {
      * @throws IllegalArgumentException se as posições de origem ou destino forem nulas.
      */
     public static Direction get(Position from, Position to) {
-        if (from == null || to == null) {
-            throw new IllegalArgumentException("Posições de origem e destino não podem ser nulas.");
-        }
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(to, "A posição de destino não pode ser nula.");
         
         if (from.equals(to)) {
             return null; // Não há direção se as posições são as mesmas.

--- a/backend/src/main/java/com/chess/entity/base/Position.java
+++ b/backend/src/main/java/com/chess/entity/base/Position.java
@@ -1,5 +1,6 @@
 package com.chess.entity.base;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,7 +52,8 @@ public class Position {
      * @throws IllegalArgumentException se a notação for nula, vazia ou inválida.
      */
     public static Position at(String string) {
-        if (string == null || string.trim().isEmpty()) {
+        Objects.requireNonNull(string, "Notação de posição não pode ser nula.");
+        if (string.trim().isEmpty()) {
             throw new IllegalArgumentException("Notação de posição não pode ser nula ou vazia.");
         }
 
@@ -97,9 +99,7 @@ public class Position {
      * @return {@code Position} se for possível andar na direção, {@code null} se não
       */
     public Position getNext(Direction direction) {
-        if (direction == null) {
-            throw new IllegalArgumentException("Direção não pode ser nula.");
-        }
+        Objects.requireNonNull(direction, "A direção não pode ser nula.");
 
         // Soma os valores do vetor com as coordenadas da posição
         int row = this.getRow() + direction.getX();

--- a/backend/src/main/java/com/chess/entity/board/Board.java
+++ b/backend/src/main/java/com/chess/entity/board/Board.java
@@ -9,6 +9,7 @@ import com.chess.entity.base.Color;
 import com.chess.entity.base.Direction;
 import com.chess.entity.base.Position;
 import com.chess.entity.piece.Piece;
+import com.chess.utils.CloneUtils;
 
 public class Board {
 
@@ -89,17 +90,12 @@ public class Board {
         return hasPieceAt(position, null);
     }
 
-    public BoardState getBoardState() {
-        return boardState;
-    }
-
-    public Color getCurrentPlayer() {
-        return currentPlayer;
-    }
-
-    public Position getEnPassantTarget() {
-        return enPassantTarget;
-    }
+    public Piece[][] getSquares() { return CloneUtils.cloneSquares(squares); }
+    public BoardState getBoardState() { return boardState; }
+    public Color getCurrentPlayer() { return currentPlayer; }
+    public Position getEnPassantTarget() { return enPassantTarget; }
+    public CastlingControl getCastlingControl() { return castlingControl; }
+    public Map<Color, Set<Position>> getPiecesPositionsByColor() { return CloneUtils.clonePiecesPositionsByColor(piecesPositionsByColor); }
 
     public boolean canCastleKingSide(Color color) {
         Objects.requireNonNull(color, "A cor não pode ser nula.");

--- a/backend/src/main/java/com/chess/entity/board/Board.java
+++ b/backend/src/main/java/com/chess/entity/board/Board.java
@@ -35,6 +35,12 @@ public class Board {
     // Mapeamento das posições das peças por cor.
     private final Map<Color, Set<Position>> piecesPositionsByColor;
 
+    // Número do movimento (incrementado após a jogada das pretas).
+    private final int fullMoveClock;
+
+    // Contador de meio-movimentos (para a regra dos 50 movimentos).
+    private final int halfMoveClock;
+
     protected Board(BoardBuilder builder) {
         this.squares = builder.getSquares();
         this.boardState = builder.getBoardState();
@@ -44,6 +50,8 @@ public class Board {
         this.whiteKingPosition = builder.getWhiteKingPosition();
         this.blackKingPosition = builder.getBlackKingPosition();
         this.piecesPositionsByColor = builder.getPiecesPositionsByColor();
+        this.fullMoveClock = builder.getFullMoveClock();
+        this.halfMoveClock = builder.getHalfMoveClock();
     }
 
     /**
@@ -85,8 +93,6 @@ public class Board {
      * @return {@code true} se houver uma peça na posição, {@code false} caso contrário.
       */
     public boolean hasPieceAt(Position position) {
-        Objects.requireNonNull(position, "A posição não pode ser nula");
-        
         return hasPieceAt(position, null);
     }
 
@@ -96,6 +102,8 @@ public class Board {
     public Position getEnPassantTarget() { return enPassantTarget; }
     public CastlingControl getCastlingControl() { return castlingControl; }
     public Map<Color, Set<Position>> getPiecesPositionsByColor() { return CloneUtils.clonePiecesPositionsByColor(piecesPositionsByColor); }
+    public int getFullMoveClock() { return fullMoveClock; }
+    public int getHalfMoveClock() { return halfMoveClock; }
 
     public boolean canCastleKingSide(Color color) {
         Objects.requireNonNull(color, "A cor não pode ser nula.");

--- a/backend/src/main/java/com/chess/entity/board/BoardBuilder.java
+++ b/backend/src/main/java/com/chess/entity/board/BoardBuilder.java
@@ -35,6 +35,12 @@ public class BoardBuilder {
     // Mapeamento das posições das peças por cor.
     private Map<Color, Set<Position>> piecesPositionsByColor;
 
+    // Número do movimento (incrementado após a jogada das pretas).
+    private int fullMoveClock;
+
+    // Contador de meio-movimentos (para a regra dos 50 movimentos).
+    private int halfMoveClock;
+
     public static final char[] standardLinePieces = {'T', 'C', 'B', 'D', 'R', 'B', 'C', 'T'};
 
     public BoardBuilder() {
@@ -42,6 +48,8 @@ public class BoardBuilder {
         this.piecesPositionsByColor = new HashMap<>();
         piecesPositionsByColor.put(Color.WHITE, new HashSet<>());
         piecesPositionsByColor.put(Color.BLACK, new HashSet<>());
+        this.fullMoveClock = 1;
+        this.halfMoveClock = 0;
     }
 
     public BoardBuilder(Board board) {
@@ -53,9 +61,12 @@ public class BoardBuilder {
         this.whiteKingPosition = board.getKingPosition(Color.WHITE);
         this.blackKingPosition = board.getKingPosition(Color.BLACK);
         this.piecesPositionsByColor = board.getPiecesPositionsByColor();
+        this.fullMoveClock = board.getFullMoveClock();
+        this.halfMoveClock = board.getHalfMoveClock();
     }
 
     public Piece[][] getSquares() { return CloneUtils.cloneSquares(squares); }
+    public Piece getPieceAt(Position position) { return squares[position.getRow()][position.getCol()]; }
     public BoardState getBoardState() { return boardState; }
     public Color getCurrentPlayer() { return currentPlayer; }
     public Position getEnPassantTarget() { return enPassantTarget; }
@@ -63,11 +74,19 @@ public class BoardBuilder {
     public Position getWhiteKingPosition() { return whiteKingPosition; }
     public Position getBlackKingPosition() { return blackKingPosition; }
     public Map<Color, Set<Position>> getPiecesPositionsByColor() { return CloneUtils.clonePiecesPositionsByColor(piecesPositionsByColor); }
+    public int getFullMoveClock() { return fullMoveClock; }
+    public int getHalfMoveClock() { return halfMoveClock; }
 
     public void setBoardState(BoardState boardState) { this.boardState = boardState; }
     public void setCurrentPlayer(Color currentPlayer) { this.currentPlayer = currentPlayer; }
     public void setEnPassantTarget(Position enPassantTarget) { this.enPassantTarget = enPassantTarget; }
     public void setCastlingControl(CastlingControl castlingControl) { this.castlingControl = castlingControl; }
+    public void setFullMoveClock(int fullMoveClock) { this.fullMoveClock = fullMoveClock; }
+    public void setHalfMoveClock(int halfMoveClock) { this.halfMoveClock = halfMoveClock; }
+
+    public void incrementFullMoveClock() { this.fullMoveClock++; }
+    public void incrementHalfMoveClock() { this.halfMoveClock++; }
+    public void resetHalfMoveClock() { this.halfMoveClock = 0; }
 
     /**
      * Configura o tabuleiro com a disposição padrão das peças.
@@ -90,10 +109,19 @@ public class BoardBuilder {
         this.currentPlayer = Color.WHITE;
         this.enPassantTarget = null;
         this.castlingControl = CastlingControl.INIT;
+        this.fullMoveClock = 1;
+        this.halfMoveClock = 0;
 
         return new Board(this);
     }
 
+    /**
+     * Constrói um objeto {@code Board} com base no estado atual do construtor.
+     * Verifica se o estado do tabuleiro é válido antes de construir o objeto.
+     * 
+     * @return um objeto {@code Board} representando o tabuleiro configurado.
+     * @throws IllegalStateException se o estado do tabuleiro for inválido.
+      */
     public Board build() {
         if (boardState == null) {
             throw new IllegalStateException("O estado do tabuleiro não foi definido.");
@@ -119,6 +147,12 @@ public class BoardBuilder {
         if (hasMoreKings(Color.BLACK)) {
             throw new IllegalStateException("Mais de um rei preto encontrado.");
         }
+        if (fullMoveClock <= 0) {
+            throw new IllegalStateException("O número do movimento deve ser maior que zero.");
+        }
+        if (halfMoveClock < 0) {
+            throw new IllegalStateException("O contador de meio-movimentos não pode ser negativo.");
+        }
         return new Board(this);
     }
 
@@ -137,6 +171,13 @@ public class BoardBuilder {
         return false;
     }
 
+    /**
+     * Configura uma linha do tabuleiro com as peças especificadas.
+     * 
+     * @param color a cor das peças a serem colocadas.
+     * @param row a linha do tabuleiro onde as peças serão colocadas.
+     * @param linePieces um array de caracteres representando as peças na linha.
+      */
     public void setRowPieces(Color color, int row, char[] linePieces) {
         for (int col = 0; col < 8; col++) {
             char pieceChar = linePieces[col];
@@ -149,6 +190,12 @@ public class BoardBuilder {
         }
     }
 
+    /**
+     * Configura uma linha do tabuleiro com peões da cor especificada.
+     * 
+     * @param color a cor dos peões a serem colocados.
+     * @param row a linha do tabuleiro onde os peões serão colocados.
+      */
     public void setRowPawns(Color color, int row) {
         for (int col = 0; col < 8; col++) {
             char pawnChar = color.isWhite() ? 'P' : 'p';
@@ -160,6 +207,15 @@ public class BoardBuilder {
         }
     }
 
+    /**
+     * Coloca uma peça na posição especificada no tabuleiro.
+     * Não remove a peça da posição anterior, se aplicável.
+     * Remove a peça existente na posição de destino, se houver.
+     * Atualiza os estados relacionados, como a posição do rei e o mapeamento das posições das peças por cor.
+     * 
+     * @param piece a peça a ser colocada.
+     * @param position a posição onde a peça será colocada.
+      */
     public void placePiece(Piece piece, Position position) {
         int row = position.getRow();
         int col = position.getCol();
@@ -182,6 +238,12 @@ public class BoardBuilder {
         }
     }
 
+    /**
+     * Remove a peça da posição especificada no tabuleiro.
+     * Atualiza os estados relacionados, como a posição do rei e o mapeamento das posições das peças por cor.
+     * 
+     * @param position a posição da peça a ser removida.
+      */
     public void removePiece(Position position) {
         int row = position.getRow();
         int col = position.getCol();

--- a/backend/src/main/java/com/chess/entity/board/BoardBuilder.java
+++ b/backend/src/main/java/com/chess/entity/board/BoardBuilder.java
@@ -7,7 +7,9 @@ import java.util.Set;
 
 import com.chess.entity.base.Color;
 import com.chess.entity.base.Position;
+import com.chess.entity.piece.King;
 import com.chess.entity.piece.Piece;
+import com.chess.utils.CloneUtils;
 
 public class BoardBuilder {
     
@@ -42,45 +44,14 @@ public class BoardBuilder {
         piecesPositionsByColor.put(Color.BLACK, new HashSet<>());
     }
 
-    public Piece[][] getSquares() {
-        Piece[][] clonedSquares = new Piece[8][];
-        for (int row = 0; row < 8; row++) {
-            clonedSquares[row] = squares[row].clone();
-        }
-        return clonedSquares;
-    }
-
-    public BoardState getBoardState() {
-        return boardState;
-    }
-
-    public Color getCurrentPlayer() {
-        return currentPlayer;
-    }
-
-    public Position getEnPassantTarget() {
-        return enPassantTarget;
-    }
-
-    public CastlingControl getCastlingControl() {
-        return castlingControl;
-    }
-
-    public Position getWhiteKingPosition() {
-        return whiteKingPosition;
-    }
-
-    public Position getBlackKingPosition() {
-        return blackKingPosition;
-    }
-
-    public Map<Color, Set<Position>> getPiecesPositionsByColor() {
-        Map<Color, Set<Position>> clonedMap = new HashMap<>();
-        for (Map.Entry<Color, Set<Position>> entry : piecesPositionsByColor.entrySet()) {
-            clonedMap.put(entry.getKey(), new HashSet<>(entry.getValue()));
-        }
-        return clonedMap;
-    }
+    public Piece[][] getSquares() { return CloneUtils.cloneSquares(squares); }
+    public BoardState getBoardState() { return boardState; }
+    public Color getCurrentPlayer() { return currentPlayer; }
+    public Position getEnPassantTarget() { return enPassantTarget; }
+    public CastlingControl getCastlingControl() { return castlingControl; }
+    public Position getWhiteKingPosition() { return whiteKingPosition; }
+    public Position getBlackKingPosition() { return blackKingPosition; }
+    public Map<Color, Set<Position>> getPiecesPositionsByColor() { return CloneUtils.clonePiecesPositionsByColor(piecesPositionsByColor); }
 
     /**
      * Configura o tabuleiro com a disposição padrão das peças.
@@ -89,6 +60,10 @@ public class BoardBuilder {
       */
     public Board buildStandard() {
         char[] linePieces = standardLinePieces;
+        squares = new Piece[8][8];
+        piecesPositionsByColor = new HashMap<>();
+        piecesPositionsByColor.put(Color.WHITE, new HashSet<>());
+        piecesPositionsByColor.put(Color.BLACK, new HashSet<>());
 
         setRowPieces(Color.WHITE, 7, linePieces);
         setRowPawns(Color.WHITE, 6);
@@ -99,13 +74,54 @@ public class BoardBuilder {
         this.currentPlayer = Color.WHITE;
         this.enPassantTarget = null;
         this.castlingControl = CastlingControl.INIT;
-        this.whiteKingPosition = Position.at(7, 4);
-        this.blackKingPosition = Position.at(0, 4);
 
         return new Board(this);
     }
 
-    private void setRowPieces(Color color, int row, char[] linePieces) {
+    public Board build() {
+        if (boardState == null) {
+            throw new IllegalStateException("O estado do tabuleiro não foi definido.");
+        }
+        if (currentPlayer == null) {
+            throw new IllegalStateException("O jogador atual não foi definido.");
+        }
+        if (castlingControl == null) {
+            throw new IllegalStateException("O controle de roque não foi definido.");
+        }
+        if (whiteKingPosition == null) {
+            throw new IllegalStateException("A posição do rei branco não foi definida.");
+        }
+        if (blackKingPosition == null) {
+            throw new IllegalStateException("A posição do rei preto não foi definida.");
+        }
+        if (whiteKingPosition.isNear(blackKingPosition)) {
+            throw new IllegalStateException("Os reis não podem estar em posições adjacentes.");
+        }
+        if (hasMoreKings(Color.WHITE)) {
+            throw new IllegalStateException("Mais de um rei branco encontrado.");
+        }
+        if (hasMoreKings(Color.BLACK)) {
+            throw new IllegalStateException("Mais de um rei preto encontrado.");
+        }
+        return new Board(this);
+    }
+
+    private boolean hasMoreKings(Color color) {
+        Set<Position> positions = piecesPositionsByColor.get(color);
+        boolean hasKing = false;
+        for (Position position : positions) {
+            Piece piece = squares[position.getRow()][position.getCol()];
+            if (piece instanceof King) {
+                if (hasKing) {
+                    return true;
+                }
+                hasKing = true;
+            }
+        }
+        return false;
+    }
+
+    public void setRowPieces(Color color, int row, char[] linePieces) {
         for (int col = 0; col < 8; col++) {
             char pieceChar = linePieces[col];
             pieceChar = color.isWhite() ? Character.toUpperCase(pieceChar) : Character.toLowerCase(pieceChar);
@@ -117,7 +133,7 @@ public class BoardBuilder {
         }
     }
 
-    private void setRowPawns(Color color, int row) {
+    public void setRowPawns(Color color, int row) {
         for (int col = 0; col < 8; col++) {
             char pawnChar = color.isWhite() ? 'P' : 'p';
             
@@ -128,7 +144,7 @@ public class BoardBuilder {
         }
     }
 
-    private void placePiece(Piece piece, Position position) {
+    public void placePiece(Piece piece, Position position) {
         int row = position.getRow();
         int col = position.getCol();
 
@@ -150,7 +166,7 @@ public class BoardBuilder {
         }
     }
 
-    private void removePiece(Position position) {
+    public void removePiece(Position position) {
         int row = position.getRow();
         int col = position.getCol();
 
@@ -158,7 +174,16 @@ public class BoardBuilder {
         if (existingPiece != null) {
             piecesPositionsByColor.get(existingPiece.getColor()).remove(position);
             squares[row][col] = null;
+            if (existingPiece instanceof King) {
+                if (existingPiece.getColor().isWhite()) {
+                    if (position.equals(whiteKingPosition)) whiteKingPosition = null;
+                } else {
+                    if (position.equals(blackKingPosition)) blackKingPosition = null;
+                }
+            }
         }
     }
+
+
 
 }

--- a/backend/src/main/java/com/chess/entity/board/BoardBuilder.java
+++ b/backend/src/main/java/com/chess/entity/board/BoardBuilder.java
@@ -3,6 +3,7 @@ package com.chess.entity.board;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.chess.entity.base.Color;
@@ -179,6 +180,17 @@ public class BoardBuilder {
      * @param linePieces um array de caracteres representando as peças na linha.
       */
     public void setRowPieces(Color color, int row, char[] linePieces) {
+        Objects.requireNonNull(color, "A cor não pode ser nula.");
+        Objects.requireNonNull(linePieces, "As peças da linha não podem ser nulas.");
+
+        if (row < 0 || row > 7) {
+            throw new IllegalArgumentException("A linha deve estar entre 0 e 7.");
+        }
+        if (linePieces.length != 8) {
+            throw new IllegalArgumentException("O array de peças da linha deve ter exatamente 8 elementos.");
+        }
+
+
         for (int col = 0; col < 8; col++) {
             char pieceChar = linePieces[col];
             pieceChar = color.isWhite() ? Character.toUpperCase(pieceChar) : Character.toLowerCase(pieceChar);
@@ -197,6 +209,12 @@ public class BoardBuilder {
      * @param row a linha do tabuleiro onde os peões serão colocados.
       */
     public void setRowPawns(Color color, int row) {
+        Objects.requireNonNull(color, "A cor não pode ser nula.");
+        
+        if (row < 0 || row > 7) {
+            throw new IllegalArgumentException("A linha deve estar entre 0 e 7.");
+        }
+
         for (int col = 0; col < 8; col++) {
             char pawnChar = color.isWhite() ? 'P' : 'p';
             
@@ -217,6 +235,9 @@ public class BoardBuilder {
      * @param position a posição onde a peça será colocada.
       */
     public void placePiece(Piece piece, Position position) {
+        Objects.requireNonNull(piece, "A peça não pode ser nula.");
+        Objects.requireNonNull(position, "A posição não pode ser nula.");
+
         int row = position.getRow();
         int col = position.getCol();
 
@@ -245,6 +266,8 @@ public class BoardBuilder {
      * @param position a posição da peça a ser removida.
       */
     public void removePiece(Position position) {
+        Objects.requireNonNull(position, "A posição não pode ser nula.");
+
         int row = position.getRow();
         int col = position.getCol();
 

--- a/backend/src/main/java/com/chess/entity/board/BoardBuilder.java
+++ b/backend/src/main/java/com/chess/entity/board/BoardBuilder.java
@@ -44,6 +44,17 @@ public class BoardBuilder {
         piecesPositionsByColor.put(Color.BLACK, new HashSet<>());
     }
 
+    public BoardBuilder(Board board) {
+        this.squares = board.getSquares();
+        this.boardState = board.getBoardState();
+        this.currentPlayer = board.getCurrentPlayer();
+        this.enPassantTarget = board.getEnPassantTarget();
+        this.castlingControl = board.getCastlingControl();
+        this.whiteKingPosition = board.getKingPosition(Color.WHITE);
+        this.blackKingPosition = board.getKingPosition(Color.BLACK);
+        this.piecesPositionsByColor = board.getPiecesPositionsByColor();
+    }
+
     public Piece[][] getSquares() { return CloneUtils.cloneSquares(squares); }
     public BoardState getBoardState() { return boardState; }
     public Color getCurrentPlayer() { return currentPlayer; }
@@ -52,6 +63,11 @@ public class BoardBuilder {
     public Position getWhiteKingPosition() { return whiteKingPosition; }
     public Position getBlackKingPosition() { return blackKingPosition; }
     public Map<Color, Set<Position>> getPiecesPositionsByColor() { return CloneUtils.clonePiecesPositionsByColor(piecesPositionsByColor); }
+
+    public void setBoardState(BoardState boardState) { this.boardState = boardState; }
+    public void setCurrentPlayer(Color currentPlayer) { this.currentPlayer = currentPlayer; }
+    public void setEnPassantTarget(Position enPassantTarget) { this.enPassantTarget = enPassantTarget; }
+    public void setCastlingControl(CastlingControl castlingControl) { this.castlingControl = castlingControl; }
 
     /**
      * Configura o tabuleiro com a disposição padrão das peças.
@@ -183,7 +199,5 @@ public class BoardBuilder {
             }
         }
     }
-
-
 
 }

--- a/backend/src/main/java/com/chess/entity/board/CastlingControl.java
+++ b/backend/src/main/java/com/chess/entity/board/CastlingControl.java
@@ -1,28 +1,41 @@
 package com.chess.entity.board;
 
+import java.util.Objects;
+
 import com.chess.entity.base.Color;
+import com.chess.entity.base.Position;
+import com.chess.entity.game.Move;
+import com.chess.entity.piece.King;
+import com.chess.entity.piece.Piece;
+import com.chess.entity.piece.Rook;
 
 public class CastlingControl {
-    private final boolean whiteKingMoved;
-    private final boolean blackKingMoved;
+    private final Integer whiteKingCol;
+    private final Integer blackKingCol;
 
-    private final boolean whiteKingSideRookMoved;
-    private final boolean whiteQueenSideRookMoved;
+    private final Integer kingSideWhiteRookCol;
+    private final Integer whiteQueenSideRookCol;
 
-    private final boolean blackKingSideRookMoved;
-    private final boolean blackQueenSideRookMoved;
+    private final Integer blackKingSideRookCol;
+    private final Integer blackQueenSideRookCol;
 
-    // Construtor padrão para o início do jogo (todos os direitos intactos)
-    public static final CastlingControl INIT = new CastlingControl(false, false, false, false, false, false);
+    public static final CastlingControl INIT = new CastlingControl(4, 4, 7, 0, 7, 0);
 
-    public CastlingControl(boolean whiteKingMoved, boolean blackKingMoved, boolean whiteKingSideRookMoved, boolean whiteQueenSideRookMoved, boolean blackKingSideRookMoved, boolean blackQueenSideRookMoved) {
-        this.whiteKingMoved = whiteKingMoved;
-        this.blackKingMoved = blackKingMoved;
-        this.whiteKingSideRookMoved = whiteKingSideRookMoved;
-        this.whiteQueenSideRookMoved = whiteQueenSideRookMoved;
-        this.blackKingSideRookMoved = blackKingSideRookMoved;
-        this.blackQueenSideRookMoved = blackQueenSideRookMoved;
+    public CastlingControl(Integer whiteKingCol, Integer blackKingCol, Integer whiteKingSideRookCol, Integer whiteQueenSideRookCol, Integer blackKingSideRookCol, Integer blackQueenSideRookCol) {
+        this.whiteKingCol = whiteKingCol;
+        this.blackKingCol = blackKingCol;
+        this.kingSideWhiteRookCol = whiteKingSideRookCol;
+        this.whiteQueenSideRookCol = whiteQueenSideRookCol;
+        this.blackKingSideRookCol = blackKingSideRookCol;
+        this.blackQueenSideRookCol = blackQueenSideRookCol;
     }
+
+    public Integer getWhiteKingCol() { return whiteKingCol; }
+    public Integer getBlackKingCol() { return blackKingCol; }
+    public Integer getKingSideWhiteRookCol() { return kingSideWhiteRookCol; }
+    public Integer getWhiteQueenSideRookCol() { return whiteQueenSideRookCol; }
+    public Integer getBlackKingSideRookCol() { return blackKingSideRookCol; }
+    public Integer getBlackQueenSideRookCol() { return blackQueenSideRookCol; }
 
     /**
      * Verifica se o jogador da cor especificada pode realizar o roque do lado do rei.
@@ -32,9 +45,9 @@ public class CastlingControl {
       */
     public boolean canCastleKingSide(Color color) {
         if (color.isWhite())
-            return !whiteKingMoved && !whiteKingSideRookMoved;
+            return whiteKingCol != null && kingSideWhiteRookCol != null;
         else 
-            return !blackKingMoved && !blackKingSideRookMoved;
+            return blackKingCol != null && blackKingSideRookCol != null;
     }
 
     /**
@@ -45,80 +58,82 @@ public class CastlingControl {
       */
     public boolean canCastleQueenSide(Color color) {
         if (color.isWhite())
-            return !whiteKingMoved && !whiteQueenSideRookMoved;
+            return whiteKingCol != null && whiteQueenSideRookCol != null;
         else
-            return !blackKingMoved && !blackQueenSideRookMoved;
+            return blackKingCol != null && blackQueenSideRookCol != null;
     }
 
-    /**
-     * Registra o movimento do rei, atualizando os direitos de roque.
-     * 
-     * @param color a cor do jogador que moveu o rei.
-     * @return um novo objeto {@link CastlingControl} com os direitos atualizados.
-      */
-    public CastlingControl kingMoved(Color color) {
-        if (color.isWhite()) {
-            return new CastlingControl(true, blackKingMoved, whiteKingSideRookMoved, whiteQueenSideRookMoved, blackKingSideRookMoved, blackQueenSideRookMoved);
-        } else {
-            return new CastlingControl(whiteKingMoved, true, whiteKingSideRookMoved, whiteQueenSideRookMoved, blackKingSideRookMoved, blackQueenSideRookMoved);
+    public CastlingControl update(Move move) {
+        Integer nWhiteKingCol = this.whiteKingCol;
+        Integer nBlackKingCol = this.blackKingCol;
+        Integer nSameWhiteKingSideRookCol = this.kingSideWhiteRookCol;
+        Integer nSameWhiteQueenSideRookCol = this.whiteQueenSideRookCol;
+        Integer nSameBlackKingSideRookCol = this.blackKingSideRookCol;
+        Integer nSameBlackQueenSideRookCol = this.blackQueenSideRookCol;
+
+        Piece movedPiece = move.getMovedPiece();
+        Position from = move.getFrom();
+        Position to = move.getTo();
+
+        // 1. Lógica de Movimento (Rei ou Torre moveu)
+        if (movedPiece instanceof King) {
+            if (movedPiece.getColor().isWhite()) {
+                nWhiteKingCol = null;
+            } else {
+                nBlackKingCol = null;
+            }
+        } else if (movedPiece instanceof Rook) {
+            if (movedPiece.getColor().isWhite()) {
+                if (matches(from, 7, nSameWhiteKingSideRookCol)) nSameWhiteKingSideRookCol = null;
+                else if (matches(from, 7, nSameWhiteQueenSideRookCol)) nSameWhiteQueenSideRookCol = null;
+            } else {
+                if (matches(from, 0, nSameBlackKingSideRookCol)) nSameBlackKingSideRookCol = null;
+                else if (matches(from, 0, nSameBlackQueenSideRookCol)) nSameBlackQueenSideRookCol = null;
+            }
         }
+
+        // 2. Lógica de Captura (Torre capturada no local de origem)
+        // Se a posição de destino de qualquer movimento for a casa de uma torre rastreada, o direito é perdido.
+        
+        // Verifica Torres Brancas (linha 7)
+        if (matches(to, 7, nSameWhiteKingSideRookCol)) nSameWhiteKingSideRookCol = null;
+        if (matches(to, 7, nSameWhiteQueenSideRookCol)) nSameWhiteQueenSideRookCol = null;
+
+        // Verifica Torres Pretas (linha 0)
+        if (matches(to, 0, nSameBlackKingSideRookCol)) nSameBlackKingSideRookCol = null;
+        if (matches(to, 0, nSameBlackQueenSideRookCol)) nSameBlackQueenSideRookCol = null;
+
+        return new CastlingControl(nWhiteKingCol, nBlackKingCol, nSameWhiteKingSideRookCol, nSameWhiteQueenSideRookCol, nSameBlackKingSideRookCol, nSameBlackQueenSideRookCol);
     }
 
-    /**
-     * Registra o movimento da torre na ala do rei, atualizando os direitos de roque.
-     * 
-     * @param color a cor do jogador que moveu a torre na ala do rei.
-     * @return um novo objeto {@link CastlingControl} com os direitos atualizados.
-      */
-    public CastlingControl kingSideRookMoved(Color color) {
-        if (color.isWhite()) {
-            return new CastlingControl(whiteKingMoved, blackKingMoved, true, whiteQueenSideRookMoved, blackKingSideRookMoved, blackQueenSideRookMoved);
-        } else {
-            return new CastlingControl(whiteKingMoved, blackKingMoved, whiteKingSideRookMoved, whiteQueenSideRookMoved, true, blackQueenSideRookMoved);
-        }
+    private boolean matches(Position pos, int row, Integer col) {
+        return col != null && pos.getRow() == row && pos.getCol() == col;
     }
 
-    /**
-     * Registra o movimento da torre na ala da dama, atualizando os direitos de roque.
-     * 
-     * @param color a cor do jogador que moveu a torre na ala da dama.
-     * @return um novo objeto {@link CastlingControl} com os direitos atualizados.
-      */
-    public CastlingControl queenSideRookMoved(Color color) {
-        if (color.isWhite()) {
-            return new CastlingControl(whiteKingMoved, blackKingMoved, whiteKingSideRookMoved, true, blackKingSideRookMoved, blackQueenSideRookMoved);
-        } else {
-            return new CastlingControl(whiteKingMoved, blackKingMoved, whiteKingSideRookMoved, whiteQueenSideRookMoved, blackKingSideRookMoved, true);
-        }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CastlingControl that = (CastlingControl) o;
+        return Objects.equals(whiteKingCol, that.whiteKingCol) &&
+                Objects.equals(blackKingCol, that.blackKingCol) &&
+                Objects.equals(kingSideWhiteRookCol, that.kingSideWhiteRookCol) &&
+                Objects.equals(whiteQueenSideRookCol, that.whiteQueenSideRookCol) &&
+                Objects.equals(blackKingSideRookCol, that.blackKingSideRookCol) &&
+                Objects.equals(blackQueenSideRookCol, that.blackQueenSideRookCol);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(whiteKingMoved, blackKingMoved, whiteKingSideRookMoved, whiteQueenSideRookMoved, blackKingSideRookMoved, blackQueenSideRookMoved);
+        return Objects.hash(whiteKingCol, blackKingCol, kingSideWhiteRookCol, whiteQueenSideRookCol, blackKingSideRookCol, blackQueenSideRookCol);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        CastlingControl other = (CastlingControl) obj;
-        if (whiteKingMoved != other.whiteKingMoved)
-            return false;
-        if (blackKingMoved != other.blackKingMoved)
-            return false;
-        if (whiteKingSideRookMoved != other.whiteKingSideRookMoved)
-            return false;
-        if (whiteQueenSideRookMoved != other.whiteQueenSideRookMoved)
-            return false;
-        if (blackKingSideRookMoved != other.blackKingSideRookMoved)
-            return false;
-        if (blackQueenSideRookMoved != other.blackQueenSideRookMoved)
-            return false;
-        return true;
+    public String toString() {
+        return "CastlingControl{" +
+                "WK=" + whiteKingCol + ", BK=" + blackKingCol +
+                ", WKR=" + kingSideWhiteRookCol + ", WQR=" + whiteQueenSideRookCol +
+                ", BKR=" + blackKingSideRookCol + ", BQR=" + blackQueenSideRookCol +
+                '}';
     }
-
 }

--- a/backend/src/main/java/com/chess/entity/board/CastlingControl.java
+++ b/backend/src/main/java/com/chess/entity/board/CastlingControl.java
@@ -44,6 +44,8 @@ public class CastlingControl {
      * @return {@code true} se o jogador pode realizar o roque do lado do rei, {@code false} caso contrário.
       */
     public boolean canCastleKingSide(Color color) {
+        Objects.requireNonNull(color, "A cor não pode ser nula.");
+
         if (color.isWhite())
             return whiteKingCol != null && kingSideWhiteRookCol != null;
         else 
@@ -57,13 +59,23 @@ public class CastlingControl {
      * @return {@code true} se o jogador pode realizar o roque do lado da dama, {@code false} caso contrário.
       */
     public boolean canCastleQueenSide(Color color) {
+        Objects.requireNonNull(color, "A cor não pode ser nula.");
+
         if (color.isWhite())
             return whiteKingCol != null && whiteQueenSideRookCol != null;
         else
             return blackKingCol != null && blackQueenSideRookCol != null;
     }
 
+    /**
+     * Atualiza o controle de direitos de roque com base no movimento realizado.
+     * 
+     * @param move o movimento realizado.
+     * @return uma nova instância de {@code CastlingControl} refletindo o estado atualizado dos direitos de roque.
+      */
     public CastlingControl update(Move move) {
+        Objects.requireNonNull(move, "O movimento não pode ser nulo.");
+
         Integer nWhiteKingCol = this.whiteKingCol;
         Integer nBlackKingCol = this.blackKingCol;
         Integer nSameWhiteKingSideRookCol = this.kingSideWhiteRookCol;

--- a/backend/src/main/java/com/chess/entity/game/Move.java
+++ b/backend/src/main/java/com/chess/entity/game/Move.java
@@ -57,8 +57,13 @@ public class Move {
     public boolean isCheckmate() { return isCheckmate; }
     public boolean isStalemate() { return isStalemate; }
 
-    @Override
-    public String toString() {
+    /**
+     * Converte o movimento para a notação algébrica padrão do xadrez.
+     * Exemplo: e4, Nf3, O-O, etc.
+     * 
+     * @return a notação algébrica do movimento.
+      */
+    public String toAlgebraicNotation() {
         StringBuilder notation = new StringBuilder();
 
         // Notação para Roque
@@ -113,6 +118,22 @@ public class Move {
         } else if (isCheck) {
             notation.append('+');
         }
+
+        return notation.toString();
+    }
+
+    /**
+     * Converte o movimento para uma notação baseada nas posições de origem e destino.
+     * Exemplo: e2-e4, d7-d5, etc.
+     * 
+     * @return a notação baseada nas posições de origem e destino do movimento.
+      */
+    public String toPositionNotation() {
+        StringBuilder notation = new StringBuilder();
+
+        notation.append(from.toString());
+        notation.append("-");
+        notation.append(to.toString());
 
         return notation.toString();
     }

--- a/backend/src/main/java/com/chess/entity/game/MoveBuilder.java
+++ b/backend/src/main/java/com/chess/entity/game/MoveBuilder.java
@@ -1,5 +1,7 @@
 package com.chess.entity.game;
 
+import java.util.Objects;
+
 import com.chess.entity.base.Position;
 import com.chess.entity.piece.King;
 import com.chess.entity.piece.Pawn;
@@ -28,70 +30,125 @@ public class MoveBuilder {
     private boolean isStalemate;
 
     public MoveBuilder(Position from, Position to, Piece movedPiece) {
-        if (from == null || to == null || movedPiece == null) {
-            throw new IllegalArgumentException("Posições e peça movida não podem ser nulas.");
-        }
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(to, "A posição de destino não pode ser nula.");
+        Objects.requireNonNull(movedPiece, "A peça movida não pode ser nula.");
+
         this.from = from;
         this.to = to;
         this.movedPiece = movedPiece;
     }
 
+    /**
+     * Define a peça capturada no movimento.
+     * 
+     * @param capturedPiece a peça capturada.
+     * @return o próprio construtor para encadeamento de chamadas.
+      */
     public MoveBuilder capturedPiece(Piece capturedPiece) {
-        if (capturedPiece == null) {
-            throw new IllegalArgumentException("Peça capturada não pode ser nula.");
-        }
+        Objects.requireNonNull(capturedPiece, "Peça capturada não pode ser nula.");
+
         this.capturedPiece = capturedPiece;
+
         return this;
     }
 
+    /**
+     * Define a peça de promoção no movimento.
+     * 
+     * @param promotionPiece a peça para a qual o peão será promovido.
+     * @return o próprio construtor para encadeamento de chamadas.
+      */
     public MoveBuilder promotionPiece(Piece promotionPiece) {
-        if (promotionPiece == null) {
-            throw new IllegalArgumentException("Peça de promoção não pode ser nula.");
-        }
+        Objects.requireNonNull(promotionPiece, "Peça de promoção não pode ser nula.");
+
         this.promotionPiece = promotionPiece;
+
         return this;
     }
 
+    /**
+     * Define que o movimento é um roque.
+     * 
+     * @param rookFrom a posição da torre no roque.
+     * @return o próprio construtor para encadeamento de chamadas.
+      */
     public MoveBuilder castling(Position rookFrom) {
-        if (rookFrom == null) {
-            throw new IllegalArgumentException("Posições do roque não podem ser nulas.");
-        }
+        Objects.requireNonNull(rookFrom, "Posição da torre no roque não pode ser nula.");
+
         this.isCastling = true;
         this.rookFrom = rookFrom;
+
         return this;
     }
 
+    /**
+     * Define que o movimento é um en passant.
+     * 
+     * @return o próprio construtor para encadeamento de chamadas.
+      */
     public MoveBuilder enPassant() {
         this.isEnPassant = true;
         return this;
     }
 
+    /**
+     * Define que o movimento necessita de desambiguação pela coluna.
+     * 
+     * @return o próprio construtor para encadeamento de chamadas.
+     */
     public MoveBuilder needColDesambiguation() {
         this.needColDesambiguation = true;
         return this;
     }
 
+    /**
+     * Define que o movimento necessita de desambiguação pela linha.
+     * 
+     * @return o próprio construtor para encadeamento de chamadas.
+      */
     public MoveBuilder needRowDesambiguation() {
         this.needRowDesambiguation = true;
         return this;
     }
 
+    /**
+     * Define que o movimento resulta em xeque.
+     * 
+     * @return o próprio construtor para encadeamento de chamadas.
+     */
     public MoveBuilder check() {
         this.isCheck = true;
         return this;
     }
 
+    /**
+     * Define que o movimento resulta em xeque-mate.
+     * 
+     * @return o próprio construtor para encadeamento de chamadas.
+      */
     public MoveBuilder checkmate() {
         this.isCheckmate = true;
         this.isCheck = true; // Xeque-mate implica xeque
         return this;
     }
 
+    /**
+     * Define que o movimento resulta em empate.
+     * 
+     * @return o próprio construtor para encadeamento de chamadas.
+      */
     public MoveBuilder stalemate() {
         this.isStalemate = true;
         return this;
     }
 
+    /**
+     * Constrói o objeto Move com as configurações definidas.
+     * Valida a consistência interna antes de criar o objeto.
+     * 
+     * @return o objeto {@code Move} construído.
+      */
     public Move build() {
         // Validações de consistência interna
         if (from.equals(to)) {

--- a/backend/src/main/java/com/chess/entity/piece/Bishop.java
+++ b/backend/src/main/java/com/chess/entity/piece/Bishop.java
@@ -1,6 +1,7 @@
 package com.chess.entity.piece;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.*;
 import com.chess.entity.board.Board;
@@ -19,9 +20,9 @@ public class Bishop extends Piece {
     
     @Override
     public boolean isAttacking(Board board, Position from, Position to) {
-        if (board == null || from == null || to == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(to, "A posição de destino não pode ser nula.");
 
         Direction dir = Direction.get(from, to);
 
@@ -35,9 +36,8 @@ public class Bishop extends Piece {
     
     @Override
     public List<Position> getPossibleMoves(Board board, Position from) {
-        if (board == null || from == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
 
         Direction[] directions = Direction.getDiagonalDirections();
 

--- a/backend/src/main/java/com/chess/entity/piece/King.java
+++ b/backend/src/main/java/com/chess/entity/piece/King.java
@@ -2,6 +2,7 @@ package com.chess.entity.piece;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.*;
 import com.chess.entity.board.Board;
@@ -60,9 +61,9 @@ public class King extends Piece {
 
     @Override
     public boolean isAttacking(Board board, Position from, Position to) {
-        if (board == null || from == null || to == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(to, "A posição de destino não pode ser nula.");
 
         // Verifica se a posição "to" está adjacente à posição "from"
         boolean isAttacking = from.isNear(to) && !from.equals(to);
@@ -72,9 +73,8 @@ public class King extends Piece {
 
     @Override
     public List<Position> getPossibleMoves(Board board, Position from) {
-        if (board == null || from == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
 
         List<Position> moves = new ArrayList<>();
 

--- a/backend/src/main/java/com/chess/entity/piece/Knight.java
+++ b/backend/src/main/java/com/chess/entity/piece/Knight.java
@@ -2,6 +2,7 @@ package com.chess.entity.piece;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.*;
 import com.chess.entity.board.Board;
@@ -24,9 +25,9 @@ public class Knight extends Piece {
 
     @Override
     public boolean isAttacking(Board board, Position from, Position to) {
-        if (board == null || from == null || to == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(to, "A posição de destino não pode ser nula.");
 
         // Cálculo dos deslocamentos
         int deltaX = from.getCol() - to.getCol();
@@ -43,9 +44,8 @@ public class Knight extends Piece {
 
     @Override
     public List<Position> getPossibleMoves(Board board, Position from) {
-        if (board == null || from == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
 
         List<Position> moves = new ArrayList<>();
 

--- a/backend/src/main/java/com/chess/entity/piece/Pawn.java
+++ b/backend/src/main/java/com/chess/entity/piece/Pawn.java
@@ -2,6 +2,7 @@ package com.chess.entity.piece;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.*;
 import com.chess.entity.board.Board;
@@ -96,9 +97,9 @@ public class Pawn extends Piece {
 
     @Override
     public boolean isAttacking(Board board, Position from, Position to) {
-        if (board == null || from == null || to == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(to, "A posição de destino não pode ser nula.");
 
         Direction dir = Direction.get(from, to);
         // Verifica se a posição é adjacente e na direção de captura
@@ -109,9 +110,8 @@ public class Pawn extends Piece {
 
     @Override
     public List<Position> getPossibleMoves(Board board, Position from) {
-        if (board == null || from == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
 
         List<Position> moves = new ArrayList<>();
 

--- a/backend/src/main/java/com/chess/entity/piece/Piece.java
+++ b/backend/src/main/java/com/chess/entity/piece/Piece.java
@@ -1,6 +1,7 @@
 package com.chess.entity.piece;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.*;
 import com.chess.entity.board.Board;
@@ -31,6 +32,8 @@ public abstract class Piece {
      * @throws IllegalArgumentException Se o símbolo for inválido.
       */
     public static Piece create(char symbol) {
+        Objects.requireNonNull(symbol, "O símbolo da peça não pode ser nulo.");
+
         Color color = Character.isUpperCase(symbol) ? Color.WHITE : Color.BLACK;
         switch (Character.toUpperCase(symbol)) {
             case 'P':

--- a/backend/src/main/java/com/chess/entity/piece/Queen.java
+++ b/backend/src/main/java/com/chess/entity/piece/Queen.java
@@ -1,6 +1,7 @@
 package com.chess.entity.piece;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.*;
 import com.chess.entity.board.Board;
@@ -19,9 +20,9 @@ public class Queen extends Piece {
 
     @Override
     public boolean isAttacking(Board board, Position from, Position to) {
-        if (board == null || from == null || to == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(to, "A posição de destino não pode ser nula.");
 
         Direction dir = Direction.get(from, to);
 
@@ -35,9 +36,8 @@ public class Queen extends Piece {
 
     @Override
     public List<Position> getPossibleMoves(Board board, Position from) {
-        if (board == null || from == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
 
         Direction[] directions = Direction.getAllDirections();
 

--- a/backend/src/main/java/com/chess/entity/piece/Rook.java
+++ b/backend/src/main/java/com/chess/entity/piece/Rook.java
@@ -1,6 +1,7 @@
 package com.chess.entity.piece;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.*;
 import com.chess.entity.board.Board;
@@ -19,9 +20,9 @@ public class Rook extends Piece {
 
     @Override
     public boolean isAttacking(Board board, Position from, Position to) {
-        if (board == null || from == null || to == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(to, "A posição de destino não pode ser nula.");
 
         Direction dir = Direction.get(from, to);
 
@@ -35,9 +36,8 @@ public class Rook extends Piece {
 
     @Override
     public List<Position> getPossibleMoves(Board board, Position from) {
-        if (board == null || from == null) {
-            throw new IllegalArgumentException("Parâmetros não podem ser nulos");
-        }
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
 
         Direction[] directions = Direction.getOrthogonalDirections();
 

--- a/backend/src/main/java/com/chess/service/MoveExecutor.java
+++ b/backend/src/main/java/com/chess/service/MoveExecutor.java
@@ -1,5 +1,7 @@
 package com.chess.service;
 
+import java.util.Objects;
+
 import com.chess.entity.base.Color;
 import com.chess.entity.base.Position;
 import com.chess.entity.board.Board;
@@ -14,7 +16,17 @@ public class MoveExecutor {
 
     BoardBuilder builder;
 
+    /**
+     * Executa um movimento no tabuleiro fornecido e retorna o novo estado do tabuleiro após o movimento.
+     * 
+     * @param board O tabuleiro atual.
+     * @param move O movimento a ser executado.
+     * @return O novo estado do tabuleiro após a execução do movimento.
+      */
     public Board executeMove(Board board, Move move) {
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(move, "O movimento não pode ser nulo.");
+        
         this.builder = new BoardBuilder(board);
 
         movePiece(move.getFrom(), move.getTo());

--- a/backend/src/main/java/com/chess/service/MoveExecutor.java
+++ b/backend/src/main/java/com/chess/service/MoveExecutor.java
@@ -1,0 +1,97 @@
+package com.chess.service;
+
+import com.chess.entity.base.Color;
+import com.chess.entity.base.Position;
+import com.chess.entity.board.Board;
+import com.chess.entity.board.BoardBuilder;
+import com.chess.entity.board.BoardState;
+import com.chess.entity.board.CastlingControl;
+import com.chess.entity.game.Move;
+import com.chess.entity.piece.Pawn;
+import com.chess.entity.piece.Piece;
+
+public class MoveExecutor {
+
+    BoardBuilder builder;
+
+    public Board executeMove(Board board, Move move) {
+        this.builder = new BoardBuilder(board);
+
+        movePiece(move.getFrom(), move.getTo());
+
+        if (move.isEnPassant()) enPassant(move);
+        else if (move.isCastling()) castle(move);
+        else if (move.isPromotion()) promote(move);
+        
+        if (move.isCheckmate()) builder.setBoardState(BoardState.CHECKMATE);
+        else if (move.isCheck()) builder.setBoardState(BoardState.CHECK);
+        else builder.setBoardState(BoardState.IN_PROGRESS);
+
+        if (builder.getCurrentPlayer().isBlack()) {
+            builder.incrementFullMoveClock();
+        }
+        
+        builder.incrementHalfMoveClock();
+        if (move.getMovedPiece() instanceof Pawn || move.isCapture()) {
+            builder.resetHalfMoveClock();
+        }
+
+        updateEnPassantTarget(move);
+        updateCastlingControl(move);
+        updateCurrentPlayer();
+
+        return builder.build();
+    }
+
+    private void movePiece(Position from, Position to) {
+        Piece piece = builder.getPieceAt(from);
+        builder.removePiece(from);
+        builder.placePiece(piece, to);
+    }
+
+    private void enPassant(Move move) {
+        Position capturedPawnPos = Position.at(move.getFrom().getRow(), move.getTo().getCol());
+        builder.removePiece(capturedPawnPos);
+    }
+
+    private void castle(Move move) {
+        Position rookFrom = move.getRookFrom();
+        Position rookTo;
+        boolean isLongCastling = move.getTo().getCol() < move.getFrom().getCol();
+
+        if (isLongCastling) {
+            rookTo = Position.at(move.getTo().getRow(), 3);
+        } else {
+            rookTo = Position.at(move.getTo().getRow(), 5);
+        }
+
+        movePiece(rookFrom, rookTo);
+    }
+
+    private void promote(Move move) {
+        builder.removePiece(move.getTo());
+        builder.placePiece(move.getPromotionPiece(), move.getTo());
+    }
+
+    private void updateCurrentPlayer() {
+        Color nextPlayer = builder.getCurrentPlayer().opposite();
+        builder.setCurrentPlayer(nextPlayer);
+    }
+
+    private void updateEnPassantTarget(Move move) {
+        Piece movedPiece = move.getMovedPiece();
+        if (!move.getFrom().isNear(move.getTo()) && movedPiece instanceof Pawn) {
+            int direction = movedPiece.getColor().isWhite() ? -1 : 1;
+            Position enPassantPos = Position.at(move.getFrom().getRow() + direction, move.getFrom().getCol());
+            builder.setEnPassantTarget(enPassantPos);
+        } else {
+            builder.setEnPassantTarget(null);
+        }
+    }
+
+    private void updateCastlingControl(Move move) {
+        CastlingControl builderCastling = builder.getCastlingControl();
+        builder.setCastlingControl(builderCastling.update(move));
+    }
+
+}

--- a/backend/src/main/java/com/chess/utils/CloneUtils.java
+++ b/backend/src/main/java/com/chess/utils/CloneUtils.java
@@ -1,0 +1,30 @@
+package com.chess.utils;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.chess.entity.base.Color;
+import com.chess.entity.base.Position;
+import com.chess.entity.piece.Piece;
+
+public class CloneUtils {
+
+    public static Map<Color, Set<Position>> clonePiecesPositionsByColor(Map<Color, Set<Position>> piecesPositionsByColor) {
+        Map<Color, Set<Position>> clonedMap = new HashMap<>();
+        for (Map.Entry<Color, Set<Position>> entry : piecesPositionsByColor.entrySet()) {
+            clonedMap.put(entry.getKey(), new HashSet<>(entry.getValue()));
+        }
+        return clonedMap;
+    }
+
+    public static Piece[][] cloneSquares(Piece[][] squares) {
+        Piece[][] clonedSquares = new Piece[8][];
+        for (int row = 0; row < 8; row++) {
+            clonedSquares[row] = squares[row].clone();
+        }
+        return clonedSquares;
+    }
+
+}

--- a/backend/src/main/java/com/chess/utils/CloneUtils.java
+++ b/backend/src/main/java/com/chess/utils/CloneUtils.java
@@ -3,6 +3,7 @@ package com.chess.utils;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.chess.entity.base.Color;
@@ -11,19 +12,49 @@ import com.chess.entity.piece.Piece;
 
 public class CloneUtils {
 
+    /**
+     * Clona um mapeamento de posições das peças por cor.
+     * 
+     * @param piecesPositionsByColor Mapeamento original das posições das peças por cor.
+     * @return Uma cópia do mapeamento fornecido.
+      */
     public static Map<Color, Set<Position>> clonePiecesPositionsByColor(Map<Color, Set<Position>> piecesPositionsByColor) {
+        Objects.requireNonNull(piecesPositionsByColor, "O mapeamento das posições das peças por cor não pode ser nulo.");
+        if (piecesPositionsByColor.size() != 2) {
+            throw new IllegalArgumentException("O mapeamento deve conter exatamente duas entradas para as cores das peças.");
+        }
+
         Map<Color, Set<Position>> clonedMap = new HashMap<>();
+
         for (Map.Entry<Color, Set<Position>> entry : piecesPositionsByColor.entrySet()) {
             clonedMap.put(entry.getKey(), new HashSet<>(entry.getValue()));
         }
+
         return clonedMap;
     }
 
+    /**
+     * Clona uma matriz bidimensional de peças do tabuleiro.
+     * 
+     * @param squares Matriz original 8x8 de peças do tabuleiro.
+     * @return Uma cópia da matriz fornecida.
+      */
     public static Piece[][] cloneSquares(Piece[][] squares) {
+        Objects.requireNonNull(squares, "A matriz de casas do tabuleiro não pode ser nula.");
+        if (squares.length != 8) {
+            throw new IllegalArgumentException("A matriz de casas do tabuleiro deve ter 8 linhas.");
+        }
+
         Piece[][] clonedSquares = new Piece[8][];
+
         for (int row = 0; row < 8; row++) {
             clonedSquares[row] = squares[row].clone();
+
+            if (clonedSquares[row].length != 8) {
+                throw new IllegalArgumentException("Cada linha da matriz de casas do tabuleiro deve ter 8 colunas.");
+            }
         }
+
         return clonedSquares;
     }
 

--- a/backend/src/main/java/com/chess/utils/MoveUtils.java
+++ b/backend/src/main/java/com/chess/utils/MoveUtils.java
@@ -2,6 +2,7 @@ package com.chess.utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.*;
 import com.chess.entity.board.Board;
@@ -18,6 +19,11 @@ public class MoveUtils {
      * @return Uma lista de posições possíveis para a peça se mover.
       */
     public static List<Position> getSlidingMoves(Board board, Color pieceColor, Position from, Direction[] directions) {
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(pieceColor, "A cor da peça não pode ser nula.");
+        Objects.requireNonNull(from, "A posição de origem não pode ser nula.");
+        Objects.requireNonNull(directions, "As direções não podem ser nulas.");
+
         List<Position> possibleMoves = new ArrayList<>();
 
         // Itera sobre cada direção fornecida


### PR DESCRIPTION
## Descrição

**Branch:** `feature/move-executor` -> `develop`

Implementação da camada de serviço responsável pela aplicação de lances (`MoveExecutor`) e geração do próximo estado do tabuleiro. Esta feature também inclui uma refatoração crítica na classe `CastlingControl` para substituir flags booleanas por índices de colunas (preparando o terreno para Chess960 e corrigindo lógica de capturas) e adiciona o rastreamento essencial de contadores de turnos (50-move rule e número de rodadas) na entidade `Board`.

---

## Implementações

### Classes Criadas
- [x] `MoveExecutor` - Service stateless responsável por receber um `Board` e um `Move`, aplicar as alterações atômicas (deslocamento, captura, roque, promoção) e transitar bandeiras de estado (En Passant, Roque, Vez do Jogador), retornando um novo `Board` imutável.

### Classes Modificadas
- [x] `CastlingControl` - Refatorada para armazenar índices inteiros das colunas das torres e reis em vez de booleanos simples. Isso corrige falhas lógicas em capturas de torres e habilita suporte futuro a **Chess960 (Fischer Random)**.
- [x] `Board` - Adição dos campos `halfMoveClock` (regra dos 50 lances) e `fullMoveClock` (contador de turnos para notação FEN).
- [x] `BoardBuilder` - Adição de métodos para manipular os novos contadores (`incrementHalfMoveClock`, `resetHalfMoveClock`, etc.) durante a construção do próximo estado.

### Funcionalidades
- [x] **Execução de Movimentos Especiais:** Lógica centralizada para aplicar Roque (movendo a torre correspondente), En Passant (removendo o peão "fantasma") e Promoção.
- [x] **Gestão de Direitos de Roque Robusta:** O `CastlingControl` agora detecta automaticamente a perda de direitos quando: o Rei move, a Torre move, ou a **Torre é capturada** (correção crítica).
- [x] **Contagem de Turnos:** O sistema agora rastreia automaticamente o número de lances completos e o contador para empate (reseta em captura/movimento de peão), essencial para conformidade com as regras da FIDE.

---

## Testes Realizados

### Testes Manuais
- [x] **Roque:** Verificado comportamento de roque curto e longo, garantindo que a torre "salta" para a posição correta.
- [x] **En Passant:** Validação da remoção do peão adversário que não estava na casa de destino do movimento.
- [x] **Captura de Torre:** Simulação de captura de uma torre "virgem" e verificação de que o direito de roque daquele lado é removido em `CastlingControl`.
- [x] **Contadores:** Verificado o incremento do `fullMoveClock` apenas após jogada das pretas e o reset do `halfMoveClock` após movimento de peão.

### Casos de Borda Testados
- [x] **Perda de Roque por Captura:** Se as brancas capturam a torre da dama das pretas (a7), o flag `blackQueenSideRookCol` torna-se nulo.
- [x] Promoção de peão resultando em xeque.

---

## Checklist de Qualidade

### Código
- [x] Código segue padrão de imutabilidade (Entidades geradas via Builder).
- [x] `MoveExecutor` utiliza `Objects.requireNonNull` e falha rápido para estados inconsistentes.
- [x] Sem dependências cíclicas entre Executor e Validador (o Executor assume que o lance é válido).

### Documentação
- [x] Javadoc atualizado em todos os métodos públicos de classes no projeto.
- [x] Nomes de métodos autoexplicativos em `MoveExecutor` (`castle`, `promote`, `updateEnPassantTarget`).

### Arquitetura
- [x] **Service Layer:** `MoveExecutor` isola a lógica de manipulação de matriz da entidade de dados.
- [x] **Scalability:** Refatoração do Roque remove hardcoding de posições clássicas, permitindo configurações iniciais aleatórias no futuro.

---

## Considerações Técnicas

### Decisões de Design
1. **Castling via Colunas (`Integer`):** Em vez de `boolean canCastleLeft`, usamos `Integer rookCol`. Isso resolve dois problemas: a) Em Chess960 as torres podem estar em qualquer lugar; b) Facilita verificar se uma peça capturada em `(0, 0)` era de fato a torre de roque ou outra peça que foi parar lá.
2. **Separação Execução vs Validação:** O `MoveExecutor` não verifica se o rei está em xeque antes de mover. Ele confia cegamente que o objeto `Move` recebido foi pré-validado ou é oriundo de uma fonte segura, focando apenas na transição de estado.
3. **Imutabilidade do Board:** A atualização de relógios (`halfMove`, `fullMove`) é feita no `BoardBuilder` antes do `build()`, mantendo o `Board` resultante estritamente imutável.