### PR TITLE
PR: Gestão de Estados e Regras de Timeout (FIDE)

### DIFF
--- a/backend/src/main/java/com/chess/entity/clock/ChessClock.java
+++ b/backend/src/main/java/com/chess/entity/clock/ChessClock.java
@@ -1,8 +1,6 @@
 package com.chess.entity.clock;
 
-import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -22,17 +20,10 @@ public class ChessClock {
     // Indica se o relógio está em execução.
     private boolean isRunning;
 
-    // Histórico de tempos para possível desfazer movimentos.
-    private Map<Color, List<Long>> historyTimeRemaining;
-
     protected ChessClock(long whiteTimeRemaining, long blackTimeRemaining, long incrementMillis, Color currentTurn) {
         this.timeRemaining = new EnumMap<>(Color.class);
         this.timeRemaining.put(Color.WHITE, whiteTimeRemaining);
         this.timeRemaining.put(Color.BLACK, blackTimeRemaining);
-
-        this.historyTimeRemaining = new EnumMap<>(Color.class);
-        this.historyTimeRemaining.put(Color.WHITE, new ArrayList<>());
-        this.historyTimeRemaining.put(Color.BLACK, new ArrayList<>());
 
         this.incrementMillis = incrementMillis;
         this.currentTurn = currentTurn;
@@ -78,33 +69,26 @@ public class ChessClock {
     public void stop() {
         if (!isRunning) return;
 
-        updateTime();
+        updateTime(0);
         this.isRunning = false;
     }
 
     public long makeMove() {
         if (!isRunning) throw new IllegalStateException("O relógio deve estar em execução para fazer um movimento.");
 
-        long timeElapsed = updateTime(this.incrementMillis, true);
+        long timeElapsed = updateTime(this.incrementMillis);
         changeTurn();
 
         return timeElapsed;
     }
 
-    private void updateTime() {
-        updateTime(0, false);
-    }
-
-    private long updateTime(long incrementMillis, boolean saveToHistory) {
+    private long updateTime(long incrementMillis) {
         long timeElapsed = System.currentTimeMillis() - lastMoveTimestamp;
         long currentTime = timeRemaining.get(currentTurn);
 
         long updatedTime = currentTime - timeElapsed;
 
-        if (saveToHistory) {
-            historyTimeRemaining.get(currentTurn).add(currentTime);
-        }
-
+        // Proteção contra negativo
         if (updatedTime < 0) {
             updatedTime = 0;
         } else {
@@ -118,21 +102,6 @@ public class ChessClock {
 
     private void changeTurn() {
         currentTurn =  currentTurn.opposite();
-        lastMoveTimestamp = System.currentTimeMillis();
-    }
-
-    public void undoMove() {
-        Color previousTurn = currentTurn.opposite();
-
-        List<Long> previousTimes = historyTimeRemaining.get(previousTurn);
-        if (previousTimes.isEmpty()) {
-            throw new IllegalStateException("Não há histórico de tempo para desfazer o movimento.");
-        }
-
-        long restoredTime = previousTimes.remove(previousTimes.size() - 1);
-        timeRemaining.put(previousTurn, restoredTime);
-
-        currentTurn = previousTurn;
         lastMoveTimestamp = System.currentTimeMillis();
     }
 

--- a/backend/src/main/java/com/chess/entity/game/Game.java
+++ b/backend/src/main/java/com/chess/entity/game/Game.java
@@ -79,19 +79,4 @@ public class Game {
             this.chessClock.makeMove();
         }
     }
-
-    /**
-     * Desfaz o último movimento, revertendo o jogo para o estado anterior.
-     * Retorna o movimento que foi desfeito.
-     */
-    public Move undoLastMove() {
-        if (moveHistory.isEmpty()) {
-            return null;
-        }
-
-        Move lastMove = moveHistory.remove(moveHistory.size() - 1);
-        boardHistory.remove(boardHistory.size() - 1);
-        chessClock.undoMove();
-        return lastMove;
-    }
 }

--- a/backend/src/main/java/com/chess/entity/game/Game.java
+++ b/backend/src/main/java/com/chess/entity/game/Game.java
@@ -100,6 +100,26 @@ public class Game {
         endGame(GameState.DRAW, GameEndReason.AGREED_DRAW);
     }
 
+    public void timeoutDraw() {
+        if (gameState != GameState.ACTIVE) {
+            throw new IllegalStateException("O jogo já acabou. Não é possível declarar empate por timeout.");
+        }
+
+        endGame(GameState.DRAW, GameEndReason.TIMEOUT);
+    }
+
+    public void timeoutLoss(Color losingPlayer) {
+        Objects.requireNonNull(losingPlayer, "O jogador que perdeu por timeout não pode ser nulo.");
+
+        if (gameState != GameState.ACTIVE) {
+            throw new IllegalStateException("O jogo já acabou. Não é possível declarar vitória por timeout.");
+        }
+
+        GameState gameState = losingPlayer.isWhite() ? GameState.BLACK_WON : GameState.WHITE_WON;
+
+        endGame(gameState, GameEndReason.TIMEOUT);
+    }
+
     public void abort() {
         if (gameState != GameState.ACTIVE) {
             throw new IllegalStateException("O jogo já acabou. Não é possível abortar.");

--- a/backend/src/main/java/com/chess/entity/game/Game.java
+++ b/backend/src/main/java/com/chess/entity/game/Game.java
@@ -23,6 +23,10 @@ public class Game {
     // Relógio de xadrez associado ao jogo.
     private final ChessClock chessClock;
 
+    // Estado do jogo (ativo, vitória, empate, etc.) pode ser inferido do estado atual do tabuleiro e do relógio.
+    private GameState gameState;
+    private GameEndReason gameEndReason;
+
     // Construtor privado para forçar uso dos métodos de fábrica
     protected Game(Board initialBoard, ChessClock chessClock) {
         this.boardHistory = new ArrayList<>();
@@ -30,6 +34,9 @@ public class Game {
 
         this.boardHistory.add(initialBoard);
         this.chessClock = chessClock;
+
+        this.gameState = GameState.fromBoardState(initialBoard.getBoardState(), initialBoard.getCurrentPlayer());
+        this.gameEndReason = GameEndReason.fromBoardState(initialBoard.getBoardState());
     }
 
     public Board getCurrentBoard() { return boardHistory.getLast(); }
@@ -37,6 +44,8 @@ public class Game {
     public List<Move> getMoveHistory() { return Collections.unmodifiableList(moveHistory); }
     public List<Board> getBoardHistory() { return Collections.unmodifiableList(boardHistory); }
     public long getTimeRemaining(Color color) { return chessClock.getTimeRemaining(color); }
+    public GameState getGameState() { return gameState; }
+    public GameEndReason getGameEndReason() { return gameEndReason; }
 
     public void startClock() { chessClock.start(); }
     public void stopClock() { chessClock.stop(); }
@@ -57,8 +66,18 @@ public class Game {
         this.moveHistory.add(move);
         this.boardHistory.add(nextBoard);
 
+        this.gameState = GameState.fromBoardState(nextBoard.getBoardState(), nextBoard.getCurrentPlayer());
+        this.gameEndReason = GameEndReason.fromBoardState(nextBoard.getBoardState());
+
         this.chessClock.start(); // Idempotente: só inicia se não estiver rodando
-        this.chessClock.makeMove();
+
+        if (this.gameState != GameState.ACTIVE) {
+            // Se acabou (Mate/Empate), para o relógio imediatamente!
+            this.chessClock.stop();
+        } else {
+            // Se continua, troca o turno e aplica incremento
+            this.chessClock.makeMove();
+        }
     }
 
     /**

--- a/backend/src/main/java/com/chess/entity/game/Game.java
+++ b/backend/src/main/java/com/chess/entity/game/Game.java
@@ -79,4 +79,39 @@ public class Game {
             this.chessClock.makeMove();
         }
     }
+
+    public void resign(Color resigningPlayer) {
+        Objects.requireNonNull(resigningPlayer, "O jogador que desiste não pode ser nulo.");
+
+        if (gameState != GameState.ACTIVE) {
+            throw new IllegalStateException("O jogo já acabou. Não é possível desistir.");
+        }
+
+        GameState gameState = resigningPlayer.isWhite() ? GameState.BLACK_WON : GameState.WHITE_WON;
+
+        endGame(gameState, GameEndReason.RESIGNATION);
+    }
+
+    public void drawByAgreement() {
+        if (gameState != GameState.ACTIVE) {
+            throw new IllegalStateException("O jogo já acabou. Não é possível aceitar empate.");
+        }
+
+        endGame(GameState.DRAW, GameEndReason.AGREED_DRAW);
+    }
+
+    public void abort() {
+        if (gameState != GameState.ACTIVE) {
+            throw new IllegalStateException("O jogo já acabou. Não é possível abortar.");
+        }
+
+        endGame(GameState.ABORTED, GameEndReason.ABORTION);
+    }
+
+    private void endGame(GameState endState, GameEndReason reason) {
+        this.chessClock.stop();
+        this.gameState = endState;
+        this.gameEndReason = reason;
+    }
+
 }

--- a/backend/src/main/java/com/chess/entity/game/GameEndReason.java
+++ b/backend/src/main/java/com/chess/entity/game/GameEndReason.java
@@ -12,7 +12,9 @@ public enum GameEndReason {
     AGREED_DRAW("Empate por acordo"),
     THREEFOLD_REPETITION("Empate por repetição tripla"),
     FIFTY_MOVE_RULE("Empate pela regra dos cinquenta lances"),
-    INSUFFICIENT_MATERIAL("Material insuficiente");
+    INSUFFICIENT_MATERIAL("Material insuficiente"),
+
+    ABORTION("Jogo abortado");
 
     private final String description;
 

--- a/backend/src/main/java/com/chess/entity/game/GameEndReason.java
+++ b/backend/src/main/java/com/chess/entity/game/GameEndReason.java
@@ -1,5 +1,7 @@
 package com.chess.entity.game;
 
+import com.chess.entity.board.BoardState;
+
 public enum GameEndReason {
     
     CHECKMATE("Xeque-mate"),
@@ -20,5 +22,18 @@ public enum GameEndReason {
 
     public String getDescription() {
         return description;
+    }
+
+    public static GameEndReason fromBoardState(BoardState state) {
+        if (state == null) return null;
+
+        return switch (state) {
+            case CHECKMATE -> CHECKMATE; // Mapeamento direto
+            case STALEMATE -> STALEMATE;
+            case DRAW_BY_INSUFFICIENT_MATERIAL -> INSUFFICIENT_MATERIAL;
+            case DRAW_BY_FIFTY_MOVE_RULE -> FIFTY_MOVE_RULE;
+            case DRAW_BY_THREEFOLD_REPETITION -> THREEFOLD_REPETITION;
+            default -> null; // IN_PROGRESS e CHECK não encerram o jogo por si sós nesta lógica
+        };
     }
 }

--- a/backend/src/main/java/com/chess/entity/game/GameEndReason.java
+++ b/backend/src/main/java/com/chess/entity/game/GameEndReason.java
@@ -1,0 +1,24 @@
+package com.chess.entity.game;
+
+public enum GameEndReason {
+    
+    CHECKMATE("Xeque-mate"),
+    RESIGNATION("Desistência"),
+
+    TIMEOUT("Tempo esgotado"),
+    STALEMATE("Empate por afogamento"),
+    AGREED_DRAW("Empate por acordo"),
+    THREEFOLD_REPETITION("Empate por repetição tripla"),
+    FIFTY_MOVE_RULE("Empate pela regra dos cinquenta lances"),
+    INSUFFICIENT_MATERIAL("Material insuficiente");
+
+    private final String description;
+
+    GameEndReason(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/src/main/java/com/chess/entity/game/GameState.java
+++ b/backend/src/main/java/com/chess/entity/game/GameState.java
@@ -1,5 +1,8 @@
 package com.chess.entity.game;
 
+import com.chess.entity.base.Color;
+import com.chess.entity.board.BoardState;
+
 public enum GameState {
     ACTIVE("Ativo"),
     WHITE_WON("Brancas venceram"),
@@ -15,5 +18,17 @@ public enum GameState {
 
     public String getDescription() {
         return description;
+    }
+
+    public static GameState fromBoardState(BoardState state, Color currentPlayer) {
+        if (state == null) return null;
+
+        if (state.isInProgress()) {
+            return ACTIVE;
+        } else if (state == BoardState.CHECKMATE) {
+            return currentPlayer == Color.WHITE ? BLACK_WON : WHITE_WON; // O jogador atual é o perdedor
+        } else {
+            return DRAW;
+        } 
     }
 }

--- a/backend/src/main/java/com/chess/entity/game/GameState.java
+++ b/backend/src/main/java/com/chess/entity/game/GameState.java
@@ -1,0 +1,19 @@
+package com.chess.entity.game;
+
+public enum GameState {
+    ACTIVE("Ativo"),
+    WHITE_WON("Brancas venceram"),
+    BLACK_WON("Pretas venceram"),
+    DRAW("Empate"),
+    ABORTED("Abortado");
+
+    private final String description;
+
+    GameState(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/src/main/java/com/chess/service/game/BoardStateEvaluator.java
+++ b/backend/src/main/java/com/chess/service/game/BoardStateEvaluator.java
@@ -2,6 +2,7 @@ package com.chess.service.game;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import com.chess.entity.base.Color;
 import com.chess.entity.base.Position;
@@ -10,6 +11,7 @@ import com.chess.entity.board.BoardAnalyzer;
 import com.chess.entity.board.BoardState;
 import com.chess.entity.game.Game;
 import com.chess.entity.piece.Bishop;
+import com.chess.entity.piece.King;
 import com.chess.entity.piece.Knight;
 import com.chess.entity.piece.Pawn;
 import com.chess.entity.piece.Piece;
@@ -122,5 +124,89 @@ public class BoardStateEvaluator {
         return MoveValidator.hasAnyLegalMove(board);
     }
 
+    /**
+     * Verifica se o jogador possui material suficiente para dar mate.
+     * Considera como verdadeiro se for possível dar mate com ajuda do adversário.
+     * 
+     * @param board O tabuleiro a ser avaliado.
+     * @param player O jogador a ser avaliado.
+     * @return {@code true} se o jogador possuir material para mate, {@code false} caso contrário.
+      */
+    public static boolean hasMatingMaterial(BaseBoard board, Color player) {
+        Objects.requireNonNull(board, "O tabuleiro não pode ser nulo.");
+        Objects.requireNonNull(player, "O jogador não pode ser nulo.");
+
+        List<Position> positions = board.getPiecesPositions(player);
+        int playerPieces = positions.size();
+
+        // Somente rei -> mate impossível
+        if (playerPieces <= 1) {
+            return false;
+        }
+
+        boolean hasKnight = false;
+        Integer firstBishopColor = null;
+
+        for (Position pos : positions) {
+            Piece p = board.getPieceAt(pos);
+
+            if (p instanceof King) {
+                continue;
+            }
+
+            // Possui peão, torre ou dama -> mate possível
+            if (p instanceof Queen || p instanceof Rook || p instanceof Pawn) {
+                return true;
+            }
+
+            // Salva se tem cavalo
+            if (p instanceof Knight) {
+                hasKnight = true;
+            } 
+
+            // Se não é nenhuma outra peça, só pode ser bispo
+            int colorSquare = (pos.getRow() + pos.getCol()) % 2;
+            if (firstBishopColor == null) {
+                firstBishopColor = colorSquare;
+            } else if (firstBishopColor != colorSquare) {
+                return true; // Bispos em cores diferentes -> mate possível
+            }
+        }
+
+        List<Position> opponentPositions = board.getPiecesPositions(player.opposite());
+        
+        // Caso de K+N
+        if (hasKnight) {
+            // Se tenho mais de 2 peças (ex: K+N+N ou K+N+B), ganha sempre.
+            // Se o oponente tiver mais de 1 peça, pode ajudar a dar mate.
+            if (playerPieces > 2 || opponentPositions.size() > 1) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        // Caso de K+BBB... (bispos de mesmas cores)
+        // Se oponente tiver bispo de cor diferente ou qualquer outra peça -> mate possível
+        for (Position pos : opponentPositions) {
+            Piece p = board.getPieceAt(pos);
+
+            if (p instanceof King) {
+                continue;
+            }
+
+            if (p instanceof Queen || p instanceof Rook || p instanceof Pawn || p instanceof Knight) {
+                return true;
+            }
+
+            int colorSquare = (pos.getRow() + pos.getCol()) % 2;
+
+            if (firstBishopColor != null && colorSquare != firstBishopColor) {
+                return true; // Bispos em cores diferentes -> mate possível
+            }
+        }
+
+        return false;
+    }
 
 }

--- a/backend/src/main/java/com/chess/service/game/GameService.java
+++ b/backend/src/main/java/com/chess/service/game/GameService.java
@@ -90,13 +90,6 @@ public class GameService {
         configTimerToEnd();
     }
 
-    /**
-     * Desfaz o último movimento realizado no jogo atual.
-      */
-    public void undoLastMove() {
-        this.game.undoLastMove();
-    }
-
     private void configTimerToEnd() {
         if (endTask != null) endTask.cancel();
 

--- a/backend/src/main/java/com/chess/service/game/GameService.java
+++ b/backend/src/main/java/com/chess/service/game/GameService.java
@@ -78,7 +78,7 @@ public class GameService {
      * @param to Posição de destino do movimento.
      * @param promotionPiece Peça para promoção, se aplicável.
       */
-    public void makeMove(Position from, Position to, Piece promotionPiece) {
+    public synchronized void makeMove(Position from, Position to, Piece promotionPiece) {
         Objects.requireNonNull(from, "Posição de origem não pode ser nula.");
         Objects.requireNonNull(to, "Posição de destino não pode ser nula.");
 
@@ -164,14 +164,28 @@ public class GameService {
             @Override
             public void run() {
                 game.stopClock();
+                timeout();
                 // TODO: Notificar fim de jogo (Timeout)
-                System.out.println("TEMPO ACABOU PARA: " + getCurrentPlayer());
             }
         };
 
         // Agendar a tarefa para encerrar o relógio após o tempo restante do jogador atual
         long timeRemaining = game.getTimeRemaining(getCurrentPlayer());
         timer.schedule(endTask, Math.max(timeRemaining, 1));
+    }
+
+    private synchronized void timeout() {
+        Color playerWhoRanOutOfTime = getCurrentPlayer();
+        Color opponent = playerWhoRanOutOfTime.opposite();
+
+        // Verifico se o VENCEDOR (por tempo) tem material suficiente para vencer
+        boolean opponentHasMatingMaterial = BoardStateEvaluator.hasMatingMaterial(getCurrentBoard(), opponent);
+
+        if (opponentHasMatingMaterial) {
+            game.timeoutLoss(playerWhoRanOutOfTime);
+        } else {
+            game.timeoutDraw();
+        }
     }
 
 }

--- a/backend/src/main/java/com/chess/service/game/GameService.java
+++ b/backend/src/main/java/com/chess/service/game/GameService.java
@@ -10,6 +10,8 @@ import com.chess.entity.board.Board;
 import com.chess.entity.board.BoardBuilder;
 import com.chess.entity.game.Game;
 import com.chess.entity.game.GameBuilder;
+import com.chess.entity.game.GameEndReason;
+import com.chess.entity.game.GameState;
 import com.chess.entity.move.Move;
 import com.chess.entity.piece.Piece;
 import com.chess.service.move.MoveExecutor;
@@ -26,7 +28,9 @@ public class GameService {
     private TimerTask startTask;
     private TimerTask endTask;
 
-    private GameService() {
+    private Color drawOffer;
+
+    public GameService() {
         this.game = GameBuilder.standardRapidGame();
         scheduleAutoStart();
     }
@@ -35,6 +39,8 @@ public class GameService {
     public Board getCurrentBoard() { return game.getCurrentBoard(); }
     public Color getCurrentPlayer() { return game.getCurrentBoard().getCurrentPlayer(); }
     public long getTimeRemaining(Color color) { return game.getTimeRemaining(color);  }
+    public GameState getGameState() { return game.getGameState(); }
+    public GameEndReason getGameEndReason() { return game.getGameEndReason(); }
 
     private void scheduleAutoStart() {
         this.startTask = new TimerTask() {
@@ -48,6 +54,10 @@ public class GameService {
         };
         // Agendar para 10 segundos
         timer.schedule(startTask, 10000);
+    }
+
+    public boolean isActive() {
+        return game.getGameState() == GameState.ACTIVE;
     }
 
     /**
@@ -72,6 +82,10 @@ public class GameService {
         Objects.requireNonNull(from, "Posição de origem não pode ser nula.");
         Objects.requireNonNull(to, "Posição de destino não pode ser nula.");
 
+        if (!isActive()) {
+            throw new IllegalStateException("O jogo não está ativo. Não é possível fazer movimentos.");
+        }
+
         if (startTask != null) {
             startTask.cancel();
             startTask = null;
@@ -87,7 +101,60 @@ public class GameService {
 
         game.commitMove(move, nextBoard);
 
-        configTimerToEnd();
+        if (isActive()) {
+            this.drawOffer = null; 
+            configTimerToEnd();
+        } else {
+            stopTimer();
+        }
+    }
+
+    public void resign(Color resigningPlayer) {
+        Objects.requireNonNull(resigningPlayer, "A cor do jogador que desiste não pode ser nula.");
+
+        if (!isActive()) {
+            throw new IllegalStateException("O jogo não está ativo. Não é possível desistir.");
+        }
+
+        stopTimer();
+        game.resign(resigningPlayer);
+    }
+
+    public void offerDraw(Color player) {
+        if (!isActive()) {
+            throw new IllegalStateException("O jogo não está ativo. Não é possível oferecer empate.");
+        }
+
+        if (drawOffer == player.opposite()) {
+            acceptDraw(player);
+        } else {
+            this.drawOffer = player;
+        }
+    }
+
+    public void acceptDraw(Color player) {
+        if (!isActive()) {
+            throw new IllegalStateException("O jogo não está ativo. Não é possível aceitar empate.");
+        }
+
+        if (drawOffer != player.opposite()) {
+            throw new IllegalStateException("Não há oferta de empate para o jogador " + player);
+        }
+
+        stopTimer();
+        game.drawByAgreement();
+    }
+
+    private void stopTimer() {
+        if (startTask != null) {
+            startTask.cancel();
+            startTask = null;
+        }
+        if (endTask != null) {
+            endTask.cancel();
+            endTask = null;
+        }
+        timer.cancel();
     }
 
     private void configTimerToEnd() {


### PR DESCRIPTION
## Descrição

**Branch:** `feature/game-state` -> `develop`

Esta branch implementa a máquina de estados oficial do jogo (`GameState` e `GameEndReason`) e integra o sistema de tempo (`ChessClock`) à lógica de execução de movimentos. O foco principal é o gerenciamento robusto do fim de jogo — seja por xeque-mate, desistência ou estouro de tempo (Timeout) — respeitando as regras da FIDE sobre material insuficiente em casos de queda de seta.

---

## Implementações

### Classes Criadas
- [x] `GameState` (Enum) - Mapeia os estados macro do jogo (`ACTIVE`, `WHITE_WON`, `BLACK_WON`, `DRAW`, `ABORTED`).
- [x] `GameEndReason` (Enum) - Captura a causa raiz do término da partida (ex: `TIMEOUT`, `RESIGNATION`, `AGREED_DRAW`).
- [x] `GameBuilder` - Factory para configuração rápida de partidas com controles de tempo padronizados (Blitz, Rapid, Bullet).

### Classes Modificadas
- [x] `Game` - Refatoração para centralizar o controle de transição de estados.
  - Implementação de `resign()` (desistência), `abort()` (abortar), `timeoutLoss()` (perda por tempo), `timeoutDraw()` (empate por tempo), `drawByAgreement()` (empate por acordo)  e lógica interna de `commitMove` para parar o relógio automaticamente ao fim do jogo.
- [x] `GameService` - Implementação da lógica de **Time Bomb** usando `java.util.Timer`.
  - Agendamento e cancelamento de tarefas de *timeout* a cada lance.
  - Sincronização (`synchronized`) para thread-safety entre requisições HTTP e eventos de Timer.
- [x] `BoardStateEvaluator` - Nova lógica `hasMatingMaterial` para determinar se um timeout resulta em Vitória ou Empate.

### Funcionalidades
- [x] **State Machine Integration:** O `Game` agora transita de forma determinística entre estados, impedindo jogadas em partidas finalizadas.
- [x] **Tratamento de Timeout Assíncrono:** O `GameService` detecta quando o tempo acaba e encerra a partida automaticamente, sem necessidade de interação do usuário.
- [x] **Regra de Insuficiência no Timeout:** Se um jogador perde por tempo, mas o oponente não tem peças suficientes para dar mate (ex: apenas Rei), o resultado é convertido corretamente para **Empate** em vez de derrota.
- [x] **Atomicidade de Movimentos:** Garantia que lances críticos no "último segundo" são processados antes do estouro do relógio.

---

## Testes Realizados

### Testes Manuais
- [x] **Cenário de Desistência:** Verificado que `resign(WHITE)` resulta em `BLACK_WON` com motivo `RESIGNATION`.
- [x] **Cenário de Timeout:**
    - Deixado o relógio zerar com material completo -> Vitória do oponente.
    - Deixado o relógio zerar contra Rei isolado -> Empate (`DRAW` / `TIMEOUT`).

### Casos de Borda Testados
- [x] **Concorrência:** Envio de movimento simultâneo ao disparo do timer para validar o funcionamento do `synchronized`.

---

## Checklist de Qualidade

### Código
- [x] Tratamento de `IllegalStateException` para tentativas de ação em jogos encerrados.
- [x] Código thread-safe na camada de serviço.

### Arquitetura
- [x] `Game` permanece agnóstico à implementação de Timers (Java Util Log), mantendo a entidade pura. A responsabilidade de *agendar* o fim é do `GameService`.
- [x] Separação clara entre *quem ganhou* (`GameState`) e *como ganhou* (`GameEndReason`).

---

## Considerações Técnicas

### Decisões de Design
**Atomicidade via `synchronized`:**
Para resolver a condição de corrida entre a Thread do Timer (background) e a Thread do Controller (requisição do jogador), os métodos `makeMove` e `timeout` foram sincronizados. Isso garante a consistência do estado final da partida.

**Lógica "Opponent Material Check":**
Ao ocorrer um timeout, instanciamos a regra FIDE que verifica o material do **oponente** (não de quem perdeu o tempo). Se o oponente tem capacidade teórica de mate (mesmo que "ajudado"), ele vence. Caso contrário, empata.